### PR TITLE
Make XDG_DATA_DIRS obey the basedir spec

### DIFF
--- a/lib/xdg/base_dir.rb
+++ b/lib/xdg/base_dir.rb
@@ -7,12 +7,11 @@ module XDG
     require 'rbconfig'
 
     sysconfdir = ::RbConfig::CONFIG['sysconfdir'] || '/etc'
-    datadir    = ::RbConfig::CONFIG['datadir']    || '/usr/share'
 
     # Standard defaults for locations.
     DEFAULTS = {
       'XDG_DATA_HOME'   => ['~/.local/share'],
-      'XDG_DATA_DIRS'   => ['/usr/local/share', datadir],
+      'XDG_DATA_DIRS'   => ['/usr/local/share', '/usr/share'],
       'XDG_CONFIG_HOME' => ['~/.config'],
       'XDG_CONFIG_DIRS' => [File.join(sysconfdir,'xdg'), sysconfdir],
       'XDG_CACHE_HOME'  => ['~/.cache'],


### PR DESCRIPTION
The "XDG Base Directory Specification" [defines](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) that when XDG_DATA_DIRS is unset the value of `/usr/local/share/:/usr/share/` should be used:
>  If $XDG_DATA_DIRS is either not set or empty, a value equal to /usr/local/share/:/usr/share/ should be used. 

`::RbConfig::CONFIG['datadir']` call in some environments (e.g. RVM installed Ruby) returns something different. In my case it was `"/home/user/.rvm/rubies/ruby-2.6.5/share"`. This violates the specification. Also due to this violation one specific software project didn't work correctly for me out-of-the box.

I think that most of the GNU/Linux installation actually define `XDG_DATA_DIRS` explicitly so this code doesn't use the fallback in most of the cases and that's why this went unnoticed. But in the cases when `XDG_DATA_DIRS` this could lead to bugs.